### PR TITLE
Md/unicode

### DIFF
--- a/contactfield/fields.py
+++ b/contactfield/fields.py
@@ -296,8 +296,8 @@ class ContactField(BaseContactField, JSONField):
             return AccessDict.prepare(default)
         return default
 
-    def from_db_value(self, value, expression, connection, *args, **kwargs):
-        value = super(ContactField, self).from_db_value(value, expression, connection, *args, **kwargs)
+    def from_db_value(self, value, expression, connection):
+        value = super(ContactField, self).from_db_value(value, expression, connection)
         if isinstance(value, dict):
             return AccessDict.prepare(value)
         return value

--- a/contactfield/fields.py
+++ b/contactfield/fields.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 import json
 
 from django.utils.translation import pgettext_lazy as _p, ugettext_lazy as _
-
 from jsonfield.fields import JSONFormField, JSONField
+from six import string_types
 
 from .utils import AccessDict, CastOnAssign
 from .widgets import NullWidget
@@ -176,7 +176,7 @@ class BaseContactField(object):
 
         # Label format and displayable names
         if label_format is not None:
-            self.label_format = str(label_format)
+            self.label_format = label_format
         if display_name is not None:
             self.display_name = display_name
 
@@ -236,7 +236,7 @@ class BaseContactField(object):
         formatting issues are encountered with the value, then a blank initial
         dictionary will be returned.
         """
-        if value and isinstance(value, str):
+        if value and isinstance(value, string_types):
             try:
                 value = json.loads(value)
             except json.JSONDecodeError:

--- a/contactfield/fields.py
+++ b/contactfield/fields.py
@@ -296,8 +296,8 @@ class ContactField(BaseContactField, JSONField):
             return AccessDict.prepare(default)
         return default
 
-    def from_db_value(self, value, expression, connection, context):
-        value = super(ContactField, self).from_db_value(value, expression, connection, context)
+    def from_db_value(self, value, expression, connection, *args, **kwargs):
+        value = super(ContactField, self).from_db_value(value, expression, connection, *args, **kwargs)
         if isinstance(value, dict):
             return AccessDict.prepare(value)
         return value

--- a/contactfield/fields.py
+++ b/contactfield/fields.py
@@ -1,6 +1,6 @@
+from __future__ import unicode_literals
+
 import json
-# python 3
-from builtins import str as unicode
 
 from django.utils.translation import pgettext_lazy as _p, ugettext_lazy as _
 
@@ -176,7 +176,7 @@ class BaseContactField(object):
 
         # Label format and displayable names
         if label_format is not None:
-            self.label_format = unicode(label_format)
+            self.label_format = str(label_format)
         if display_name is not None:
             self.display_name = display_name
 
@@ -236,7 +236,7 @@ class BaseContactField(object):
         formatting issues are encountered with the value, then a blank initial
         dictionary will be returned.
         """
-        if value and isinstance(value, (unicode, str)):
+        if value and isinstance(value, str):
             try:
                 value = json.loads(value)
             except json.JSONDecodeError:

--- a/contactfield/fields.py
+++ b/contactfield/fields.py
@@ -9,6 +9,11 @@ from six import string_types
 from .utils import AccessDict, CastOnAssign
 from .widgets import NullWidget
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 
 class BaseContactField(object):
     """
@@ -176,7 +181,7 @@ class BaseContactField(object):
 
         # Label format and displayable names
         if label_format is not None:
-            self.label_format = label_format
+            self.label_format = unicode(label_format)
         if display_name is not None:
             self.display_name = display_name
 

--- a/contactfield/fields.py
+++ b/contactfield/fields.py
@@ -301,8 +301,8 @@ class ContactField(BaseContactField, JSONField):
             return AccessDict.prepare(default)
         return default
 
-    def from_db_value(self, value, expression, connection):
-        value = super(ContactField, self).from_db_value(value, expression, connection)
+    def from_db_value(self, value, expression, connection, *args, **kwargs):
+        value = super(ContactField, self).from_db_value(value, expression, connection, *args, **kwargs)
         if isinstance(value, dict):
             return AccessDict.prepare(value)
         return value

--- a/contactfield/forms.py
+++ b/contactfield/forms.py
@@ -83,14 +83,14 @@ class ContactFieldFormMixin(object):
                     pseudo_field = FieldClass(
                         initial=initial,
                         label=field.label_format.format(
-                            field=field.display_name,
-                            group=field.group_display_names.get(
+                            field=unicode(field.display_name),
+                            group=unicode(field.group_display_names.get(
                                 valid_group, pretty_name(valid_group)
-                            ),
-                            label=field.label_display_names.get(
+                            )),
+                            label=unicode(field.label_display_names.get(
                                 valid_label, pretty_name(valid_label)
                             ),
-                        ),
+                        )),
                         **field_kwargs
                     )
 

--- a/contactfield/forms.py
+++ b/contactfield/forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from functools import partial
 
 from django import forms
@@ -5,9 +7,6 @@ from django.forms.forms import pretty_name
 from django.utils.translation import ugettext_lazy as _
 
 from .fields import ContactFormField
-
-# python 3
-from builtins import str as unicode
 
 
 class ContactFieldFormMixin(object):
@@ -84,13 +83,13 @@ class ContactFieldFormMixin(object):
                     pseudo_field = FieldClass(
                         initial=initial,
                         label=field.label_format.format(
-                            field=unicode(field.display_name),
-                            group=unicode(field.group_display_names.get(
+                            field=field.display_name,
+                            group=field.group_display_names.get(
                                 valid_group, pretty_name(valid_group)
-                            )),
-                            label=unicode(field.label_display_names.get(
+                            ),
+                            label=field.label_display_names.get(
                                 valid_label, pretty_name(valid_label)
-                            ))
+                            ),
                         ),
                         **field_kwargs
                     )

--- a/contactfield/forms.py
+++ b/contactfield/forms.py
@@ -94,8 +94,8 @@ class ContactFieldFormMixin(object):
                             )),
                             label=unicode(field.label_display_names.get(
                                 valid_label, pretty_name(valid_label)
-                            ),
-                        )),
+                            )),
+                        ),
                         **field_kwargs
                     )
 

--- a/contactfield/forms.py
+++ b/contactfield/forms.py
@@ -8,6 +8,11 @@ from django.utils.translation import ugettext_lazy as _
 
 from .fields import ContactFormField
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 
 class ContactFieldFormMixin(object):
     """

--- a/contactfield/templatetags/contactfield_tags.py
+++ b/contactfield/templatetags/contactfield_tags.py
@@ -39,13 +39,13 @@ def contact_cards(obj, concise=True):
             for label in field._valid_labels:
                 value = values.get(group, {}).get(label, '')
                 display_name = field.label_format.format(
-                    field=field.display_name,
-                    group=field.group_display_names.get(
+                    field=unicode(field.display_name),
+                    group=unicode(field.group_display_names.get(
                         group, pretty_name(group)
-                    ),
-                    label=field.label_display_names.get(
+                    )),
+                    label=unicode(field.label_display_names.get(
                         label, pretty_name(label)
-                    ),
+                    )),
                 )
                 if value or not concise:
                     contact_card_dict[field_name][group][label] = {

--- a/contactfield/templatetags/contactfield_tags.py
+++ b/contactfield/templatetags/contactfield_tags.py
@@ -1,6 +1,6 @@
+from __future__ import unicode_literals
+
 from collections import OrderedDict
-# py3
-from builtins import str as unicode
 
 from django import forms
 from django import template
@@ -39,13 +39,13 @@ def contact_cards(obj, concise=True):
             for label in field._valid_labels:
                 value = values.get(group, {}).get(label, '')
                 display_name = field.label_format.format(
-                    field=unicode(field.display_name),
-                    group=unicode(field.group_display_names.get(
+                    field=field.display_name,
+                    group=field.group_display_names.get(
                         group, pretty_name(group)
-                    )),
-                    label=unicode(field.label_display_names.get(
+                    ),
+                    label=field.label_display_names.get(
                         label, pretty_name(label)
-                    ))
+                    ),
                 )
                 if value or not concise:
                     contact_card_dict[field_name][group][label] = {

--- a/contactfield/templatetags/contactfield_tags.py
+++ b/contactfield/templatetags/contactfield_tags.py
@@ -10,6 +10,11 @@ from contactfield.fields import BaseContactField
 
 from django.forms.forms import pretty_name
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 register = template.Library()
 
 

--- a/contactfield/tests.py
+++ b/contactfield/tests.py
@@ -1,4 +1,6 @@
-from builtins import str as unicode  # python 3
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from unittest import TestCase
 
 from django import forms
@@ -46,7 +48,7 @@ class FormFieldTest(TestCase):
         field = self.field_class(
             valid_groups=['a', 'b'],
             valid_labels=['1', '2'],
-            label_format='{label}',
+            label_format='{кот}',
             display_name='Name',
             concise=True
         )
@@ -60,10 +62,11 @@ class FormFieldTest(TestCase):
         )
         self.assertEquals(
             field.label_format,
-            '{label}'
+            '{кот}'
         )
+        assert field.label_format.encode() == b'{\xd0\xba\xd0\xbe\xd1\x82}'
         self.assertTrue(
-            isinstance(field.label_format, unicode)
+            isinstance(field.label_format, str)
         )
         self.assertEquals(
             field.display_name,

--- a/contactfield/tests.py
+++ b/contactfield/tests.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from unittest import TestCase
 
 from django import forms
+from six import string_types
 
 from .fields import BaseContactField, ContactFormField, ContactField
 from .forms import ContactFieldFormMixin
@@ -64,9 +65,8 @@ class FormFieldTest(TestCase):
             field.label_format,
             '{кот}'
         )
-        assert field.label_format.encode() == b'{\xd0\xba\xd0\xbe\xd1\x82}'
         self.assertTrue(
-            isinstance(field.label_format, str)
+            isinstance(field.label_format, string_types)
         )
         self.assertEquals(
             field.display_name,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     python_requires='>=3.7.0',
     install_requires=[
         "Django>=2.2, <3.0",
-        "django-jsonfield>=1.4.1"
+        "django-jsonfield"
     ],
     extras_require={
         "testing": [

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,8 @@ setup(
     packages=['contactfield', 'contactfield.templatetags'],
     description='Customisable contact field for Django',
     long_description=open('README.md').read(),
-    python_requires='>=3.7.0',
     install_requires=[
-        "Django>=2.2, <3.0",
+        "django<3",
         "django-jsonfield"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(
     long_description=open('README.md').read(),
     python_requires='>=3.7.0',
     install_requires=[
-        "Django>=1.11, <2.0",
-        "django-jsonfield==1.4.1"
+        "Django>=2.2, <3.0",
+        "django-jsonfield>=1.4.1"
     ],
     extras_require={
         "testing": [


### PR DESCRIPTION
Remove the builtins imports as these do not work in python2
Alias str as unicode for python3
Add some actual unicode in the tests
Restore the args and kwargs for the from_db method

This should now work fine in both python2 and 3